### PR TITLE
Remove antialiasing declaration

### DIFF
--- a/stylesheets/atom.less
+++ b/stylesheets/atom.less
@@ -2,7 +2,6 @@
 
 * {
 	box-sizing: border-box;
-	-webkit-font-smoothing: antialiased;
 }
 
 .workspace {


### PR DESCRIPTION
Improves text readability by removing `-webkit-font-smoothing`
My editor is set to use Monaco, 12px

Before: 
![before](https://f.cloud.github.com/assets/77198/2310792/0828eeba-a2e9-11e3-8bda-872b103c1d04.jpg)

After:
![after](https://f.cloud.github.com/assets/77198/2310802/20640320-a2e9-11e3-8510-c77ba9761359.jpg)
