### PR TITLE
Make close-icon only ease on hover

### DIFF
--- a/stylesheets/tabs.less
+++ b/stylesheets/tabs.less
@@ -35,7 +35,9 @@
     .close-icon {
       z-index: 3;
       line-height: @tab-height;
-      transition: color .1s ease-in;
+      &:hover {
+        transition: color .1s ease-in;
+      }
     }
 
     &.modified:not(:hover) .close-icon {


### PR DESCRIPTION
Currently there's a weird display thing where hovering over the active
tab will highlight at different time intervals. I think that two
different 0.1s ease-ins are compounding and causing weird timing on the
close icon. This should fix that.

Signed-off-by: David Celis me@davidcel.is
